### PR TITLE
make compatible with node-canvas for nodejs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,14 @@ var worker = require('./worker');
 * @returns {Object}
 */
 function getCanvas(w, h) {
-    var canvas = document.createElement('canvas');
-    canvas.width = w;
-    canvas.height = h;
-
+    if (typeof document === "undefined") {
+      var Canvas = require("canvas");
+      var canvas = new Canvas(w, h);
+    } else {
+      var canvas = document.createElement('canvas');
+      canvas.width = w;
+      canvas.height = h;
+    }
     return canvas;
 }
 


### PR DESCRIPTION
I've been working on a browser/nonbrowser compatible image processing lib over at https://github.com/publiclab/image-sequencer and found that I couldn't run this headless due to the need for a canvas API. In my own code, I've used the included switch to `node-canvas` to get around this, but the problem is that you can't browserify node-canvas. In my own attempts, I just overrode the `canvas` module in `package.json` like this:

```js
  "browser": {
    "canvas": "./src/browser/empty.js"
  },
```

But I don't know if that's best practice. Is this something you'd be able to support, or have opinions about? The included changes would also have to be applied to `convertImageDataToCanvasURL()`.